### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@
 - **Watch mode** — auto-re-ingest on file changes
 - **PostgreSQL ready** — pgvector + tsvector when you need scale
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/nicholasglazer-gnosis-mcp).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/nicholasglazer-gnosis-mcp).